### PR TITLE
Полностью выпилен jQuery

### DIFF
--- a/assets/components/tvtable/js/mgr/tvtable.js
+++ b/assets/components/tvtable/js/mgr/tvtable.js
@@ -1,60 +1,14 @@
-var methods = {
-    fidd: null,
-    init : function(fid) {
-        fidd = $('#'+fid);
-        $fid = $('#'+fid);
-        fldval = $fid.val();
-        var tvtArr = fldval ? Ext.util.JSON.decode(fldval) : [["",""], ["",""]];
-        $fid.hide();
-        $box = $fid.next();
-        methods.addHeader(tvtArr[0]);
-        for (var row=1;row < tvtArr.length;row++) {
-            methods.addItem(tvtArr[row], null, fid);
+var TVTable = {
+    _createElement: function (type, attributes) {
+        var element = document.createElement(type);
+        for (key in attributes) {
+            element.setAttribute(key, attributes[key]);
         }
-    },
-    addHeader: function(values,elem){
-        $rowDiv = $('<div class="tvtrow header"></div>');
-        $box.append($rowDiv);
-        if (!values) values=['',''];
-        for (var i=0;i<values.length;i++) {
-            $rowDiv.append(methods.build(values[i]));
-        }
-        $add = $('<input type="button" value="&#xf054;" title="'+_('tvtable.add_column')+'" class="add x-btn x-btn-small">  ');
-        $rowDiv.append($add);
-        $del = $('<input type="button" value="&#xf053;" title="'+_('tvtable.del_column')+'"  class="del x-btn x-btn-small"> ');
-        $rowDiv.append($del);
-    },
-    build: function(val){
-        return $('<input type="text" class="x-form-text x-form-field" value="'+val+'" ></input> ');
-    },
-    addItem: function(values,elem, fidd){
-        fidd = '#'+fidd;
-        $rowDiv = $('<div class="tvtrow" style="white-space: nowrap; padding :5px 0; "></div>')
-        if (elem){
-            $rowDiv.insertAfter(elem);
-            }else{
-            $(fidd).next().append($rowDiv);
-        }
-        
-        if(typeof values == 'number'){
-            for (var i=0;i<values;i++) {
-                $rowDiv.append(methods.build(''));
-            }
-            }else{
-            for (var i=0;i<values.length;i++) {
-                $rowDiv.append(methods.build((values) ? values[i] : ''));
-            }
-        }
-        
-        $rowDiv.append('<input type="button" value="&#xf078;"   title="'+_('tvtable.add_row')+'" class="add_item x-btn x-btn-small">');
-        
-        if ($(fidd).next().find('div.tvtrow').length > 2){
-            $rowDiv.append('<input type="button" value="&#xf077;" title="'+_('tvtable.del_row')+'" class="del_item x-btn x-btn-small">');
-        }
-    },
-    checkArray: function(array) {
-        if (!Ext.isArray(array)) return false;
 
+        return element;
+    }
+    ,_checkArray: function(array) {
+        if (!Ext.isArray(array)) return false;
         var values = 0;
         array.forEach(function(item, i, array) {
             if (Ext.isArray(array)) {
@@ -67,71 +21,229 @@ var methods = {
         });
         
         return values > 0 ? true : false;
-    },
-    setEditor: function(fid){
-        var tvtArr = new Array();
-        $('#'+fid).next().find('div.tvtrow').each(function(item){
-            var itemsArr = new Array();
-            $inputs = $(this).find('input[type=text]');
-            $inputs.each(function(item){
-                itemsArr.push($(this).val());}
-            );
-            tvtArr.push(itemsArr);
+    }
+    ,_insertAfter: function (elem, refElem) {
+        var parent = refElem.parentNode;
+        var next = refElem.nextSibling;
+
+        if (next) {
+            return parent.insertBefore(elem, next);
+        } else {
+            return parent.appendChild(elem);
+        }
+    }
+    ,init: function(fid) {
+        var field = document.getElementById(fid);
+        var fldval = field.value;
+        var tvtArr = fldval ? Ext.util.JSON.decode(fldval) : [["",""], ["",""]];
+        field.style.display = 'none';
+
+        TVTable.addHeader(tvtArr[0], field);
+        for (var row = 1; row < tvtArr.length; row++) {
+            TVTable.addItem(tvtArr[row], null, fid);
+        }
+    }
+    ,addHeader: function(values, field){
+        var rowDiv = TVTable._createElement('div', {class: 'tvtrow header'});
+
+        var box = field.nextSibling;
+        while(box && box.nodeType != 1) {
+            box = box.nextSibling
+        }
+        box.appendChild(rowDiv);
+
+        if (!values) values = ['',''];
+
+        for (var i = 0; i < values.length; i++) {
+            rowDiv.appendChild(TVTable.build(values[i]));
+        }
+
+        rowDiv.appendChild(TVTable._createElement('input', {
+            type: 'button'
+            ,value: '\uF054'
+            ,title: _('tvtable.add_column')
+            ,class: 'add x-btn x-btn-small'
+        }));
+
+        rowDiv.appendChild(TVTable._createElement('input', {
+            type: 'button'
+            ,value: '\uf053'
+            ,title: _('tvtable.del_column')
+            ,class: 'del x-btn x-btn-small'
+        }));
+    }
+    ,build: function(val) {
+        return TVTable._createElement('input', {
+            type: 'text'
+            ,value: val
+            ,class: 'x-form-text x-form-field'
+        });
+    }
+    ,addItem: function(values, elem, fidd) {        
+        var rowDiv = TVTable._createElement('div', {
+            type: 'text'
+            ,class: 'tvtrow'
+            ,style: 'white-space: nowrap; padding: 5px 0;'
         });
 
-        if (methods.checkArray(tvtArr)) {
-            var vl = JSON.stringify(tvtArr);
-            $('#'+fid).val(vl);
+        var field = document.getElementById(fidd);
+        var next = field.nextSibling;
+
+        while (next && next.nodeType != 1) {
+            next = next.nextSibling;
+        }
+
+        if (elem) {
+            TVTable._insertAfter(rowDiv, elem);
         } else {
-            $('#'+fid).val('');
+            next.appendChild(rowDiv);
+        }
+        
+        if (typeof values == 'number') {
+            for (var i = 0; i < values; i++) {
+                rowDiv.appendChild(TVTable.build(''));
+            }
+        } else {
+            for (var i = 0; i < values.length; i++) {
+                rowDiv.appendChild(TVTable.build((values) ? values[i] : ''));
+            }
+        }
+
+        rowDiv.appendChild(TVTable._createElement('input', {
+            type: 'button'
+            ,value: '\uf078'
+            ,title: _('tvtable.add_row')
+            ,class: 'add_item x-btn x-btn-small'
+        }));
+        
+        if (next.querySelectorAll('.tvtrow').length > 2) {
+            rowDiv.appendChild(TVTable._createElement('input', {
+                type: 'button'
+                ,value: '\uf077'
+                ,title: _('tvtable.del_row')
+                ,class: 'del_item x-btn x-btn-small'
+            }));
+        }
+    }
+    ,setEditor: function(fid){
+        var tvtArr = new Array();
+
+        var field = document.getElementById(fid);
+        var next = field.nextSibling;
+
+        while (next && next.nodeType != 1) {
+            next = next.nextSibling;
+        }
+        var rows = next.querySelectorAll('.tvtrow');
+
+        for (var x = 0; x < rows.length; x++) {
+            var itemsArr = new Array();
+            var inputs = rows[x].querySelectorAll('input[type="text"]');
+
+            for (var y = 0; y < inputs.length; y++) {
+                var item = inputs[y];
+                itemsArr.push(item.value);
+            }
+
+            tvtArr.push(itemsArr);
+        }
+
+        if (TVTable._checkArray(tvtArr)) {
+            var value = JSON.stringify(tvtArr);
+            field.value = value;
+        } else {
+            field.value = '';
         }
 
         MODx.fireResourceFormChange();
     }
-};
+}
 
-$.myPlug = function(method) {
-    if (methods[method]) {
-            return methods[method].apply(this, Array.prototype.slice.call(arguments, 1));
-        } else if (typeof method === 'object' || ! method) {
-            return methods.init.apply(this, arguments);
-        } else {
-            $.error( 'No method ' +  method + ' exists for $.chats' );
-    } 
-};
-
-$('body, html').on('keyup', 'input[type="text"]', function(){
-    $.myPlug('setEditor', $(this).closest('.tvtEditor').prev().attr('id'));
-    MODx.fireResourceFormChange();
-});
-
-// add row
-$('body, html').on('click', '.add_item', function(){
-    $.myPlug('addItem', $(this).parent().find('input[type="text"]').length,$(this).parent(), $(this).closest('.tvtEditor').prev().attr('id'));
-    $.myPlug('setEditor', $(this).closest('.tvtEditor').prev().attr('id'));
-});
-// delete row
-$('body, html').on('click', '.del_item', function(){
-    var iff = $(this).closest('.tvtEditor').prev().attr('id')
-    $(this).parent().remove();
-    $.myPlug('setEditor', iff);
-});
-
-// delete column
-$('body, html').on('click', '.del', function(){
-    var iff = $(this).closest('.tvtEditor').prev().attr('id')
-    if ($(this).parent().find('input[type=text]').length>2){
-        $('#' + iff).next().find('div.tvtrow').each(function(item){
-            $(this).find('input[type=text]').last().remove();
-        });
-        $.myPlug('setEditor', iff);
+document.onkeyup = function (e) {
+    if (e.target.type == 'text') {
+        var prev = e.target.closest('.tvtEditor').previousSibling;
+        while (prev && prev.nodeType != 1) {
+            prev = prev.previousSibling;
+        }
+        TVTable.setEditor(prev.id);
     }
-});
-// add column
-$('body, html').on('click', '.add', function(){
-    var iff = $(this).closest('.tvtEditor').prev().attr('id');
-    $('#' + iff).next().find('div.tvtrow').each(function(item){
-        methods.build('').insertAfter($(this).find('input[type=text]').last());
-    });
-    $.myPlug('setEditor', iff);
-});
+}
+
+document.onclick = function (e) {
+    // Add row
+    if (e.target.classList.contains('add_item')) {
+        var parent = e.target.parentNode;
+        var length = parent.querySelectorAll('input[type="text"]').length;
+        var input = e.target.closest('.tvtEditor').previousSibling;
+    
+        while (input && input.nodeType != 1) {
+            input = input.previousSibling;
+        }
+    
+        TVTable.addItem(length, parent, input.id);
+        TVTable.setEditor(input.id);
+    }
+    // Remove row
+    if (e.target.classList.contains('del_item')) {
+        var prev = e.target.closest('.tvtEditor').previousSibling;
+        var parent = e.target.parentNode;
+        while (prev && prev.nodeType != 1) {
+            prev = prev.previousSibling;
+        }
+
+        parent.remove();
+        TVTable.setEditor(prev.id);
+    }
+    // delete column
+    if (e.target.classList.contains('del')) {
+        var prev = e.target.closest('.tvtEditor').previousSibling;
+        while (prev && prev.nodeType != 1) {
+            prev = prev.previousSibling;
+        }
+
+        var parent = e.target.parentNode;
+        var length = parent.querySelectorAll('input[type="text"]').length;
+
+        var next = prev.nextSibling;
+        while (next && next.nodeType != 1) {
+            next = next.nextSibling;
+        }
+
+        var rows = next.querySelectorAll('.tvtrow');
+
+        if (length > 2) {
+            for (var i = 0; i < rows.length; i++) {
+                var row = rows[i];
+                var inputs = row.querySelectorAll('input[type=text]');
+
+                inputs[inputs.length - 1].remove();
+            }
+            TVTable.setEditor(prev.id);
+        }
+    }
+    // add column
+    if (e.target.classList.contains('add')) {
+        var prev = e.target.closest('.tvtEditor').previousSibling;
+        while (prev && prev.nodeType != 1) {
+            prev = prev.previousSibling;
+        }
+
+        var parent = e.target.parentNode;
+        var length = parent.querySelectorAll('input[type="text"]').length;
+
+        var next = prev.nextSibling;
+        while (next && next.nodeType != 1) {
+            next = next.nextSibling;
+        }
+
+        var rows = next.querySelectorAll('.tvtrow');
+
+        for (var i = 0; i < rows.length; i++) {
+            var row = rows[i];
+            var inputs = row.querySelectorAll('input[type=text]');
+
+            TVTable._insertAfter(TVTable.build(''), inputs[inputs.length - 1])
+        }
+        TVTable.setEditor(prev.id);
+    }
+}

--- a/assets/components/tvtable/js/mgr/tvtable.js
+++ b/assets/components/tvtable/js/mgr/tvtable.js
@@ -32,6 +32,22 @@ var TVTable = {
             return parent.appendChild(elem);
         }
     }
+    ,getPrevSibling: function (elem, selector) {
+        var sibling = elem.previousElementSibling;
+        if (!selector) return sibling;
+        while (sibling) {
+            if (sibling.matches(selector)) return sibling;
+            sibling = sibling.previousElementSibling;
+        }
+    }
+    ,getNextSibling: function (elem, selector) {
+        var sibling = elem.nextElementSibling;
+        if (!selector) return sibling;
+        while (sibling) {
+            if (sibling.matches(selector)) return sibling;
+            sibling = sibling.nextElementSibling
+        }
+    }
     ,init: function(fid) {
         var field = document.getElementById(fid);
         var fldval = field.value;
@@ -87,11 +103,7 @@ var TVTable = {
         });
 
         var field = document.getElementById(fidd);
-        var next = field.nextSibling;
-
-        while (next && next.nodeType != 1) {
-            next = next.nextSibling;
-        }
+        var next = TVTable.getNextSibling(field);
 
         if (elem) {
             TVTable._insertAfter(rowDiv, elem);
@@ -129,11 +141,7 @@ var TVTable = {
         var tvtArr = new Array();
 
         var field = document.getElementById(fid);
-        var next = field.nextSibling;
-
-        while (next && next.nodeType != 1) {
-            next = next.nextSibling;
-        }
+        var next = TVTable.getNextSibling(field);
         var rows = next.querySelectorAll('.tvtrow');
 
         for (var x = 0; x < rows.length; x++) {
@@ -203,12 +211,7 @@ document.onclick = function (e) {
 
         var parent = e.target.parentNode;
         var length = parent.querySelectorAll('input[type="text"]').length;
-
-        var next = prev.nextSibling;
-        while (next && next.nodeType != 1) {
-            next = next.nextSibling;
-        }
-
+        var next = TVTable.getNextSibling(prev);
         var rows = next.querySelectorAll('.tvtrow');
 
         if (length > 2) {
@@ -223,19 +226,11 @@ document.onclick = function (e) {
     }
     // add column
     if (e.target.classList.contains('add')) {
-        var prev = e.target.closest('.tvtEditor').previousSibling;
-        while (prev && prev.nodeType != 1) {
-            prev = prev.previousSibling;
-        }
+        var prev = TVTable.getPrevSibling(e.target.closest('.tvtEditor'));
 
         var parent = e.target.parentNode;
         var length = parent.querySelectorAll('input[type="text"]').length;
-
-        var next = prev.nextSibling;
-        while (next && next.nodeType != 1) {
-            next = next.nextSibling;
-        }
-
+        var next = TVTable.getNextSibling(prev);
         var rows = next.querySelectorAll('.tvtrow');
 
         for (var i = 0; i < rows.length; i++) {

--- a/assets/components/tvtable/js/mgr/tvtable.js
+++ b/assets/components/tvtable/js/mgr/tvtable.js
@@ -1,10 +1,10 @@
 var methods = {
-    fidd: null, 
-    init : function(fid) { 
+    fidd: null,
+    init : function(fid) {
         fidd = $('#'+fid);
         $fid = $('#'+fid);
-        var tvtArr = ($fid.val()) ? $.parseJSON($fid.val()) : [["",""], ["",""]];
-        console.log(fid)
+        fldval = $fid.val();
+        var tvtArr = fldval ? Ext.util.JSON.decode(fldval) : [["",""], ["",""]];
         $fid.hide();
         $box = $fid.next();
         methods.addHeader(tvtArr[0]);
@@ -19,7 +19,7 @@ var methods = {
         for (var i=0;i<values.length;i++) {
             $rowDiv.append(methods.build(values[i]));
         }
-        $add = $(' <input type="button" value="&#xf054;" title="'+_('tvtable.add_column')+'" class="add x-btn x-btn-small">  ');
+        $add = $('<input type="button" value="&#xf054;" title="'+_('tvtable.add_column')+'" class="add x-btn x-btn-small">  ');
         $rowDiv.append($add);
         $del = $('<input type="button" value="&#xf053;" title="'+_('tvtable.del_column')+'"  class="del x-btn x-btn-small"> ');
         $rowDiv.append($del);
@@ -52,18 +52,40 @@ var methods = {
             $rowDiv.append('<input type="button" value="&#xf077;" title="'+_('tvtable.del_row')+'" class="del_item x-btn x-btn-small">');
         }
     },
+    checkArray: function(array) {
+        if (!Ext.isArray(array)) return false;
+
+        var values = 0;
+        array.forEach(function(item, i, array) {
+            if (Ext.isArray(array)) {
+                item.forEach(function(item, i, array) {
+                    if (item !== '') {
+                        values++;
+                    }
+                });
+            }
+        });
+        
+        return values > 0 ? true : false;
+    },
     setEditor: function(fid){
-        var tvtArr=new Array();
+        var tvtArr = new Array();
         $('#'+fid).next().find('div.tvtrow').each(function(item){
-            var itemsArr=new Array();
-            $inputs=$(this).find('input[type=text]');
+            var itemsArr = new Array();
+            $inputs = $(this).find('input[type=text]');
             $inputs.each(function(item){
-            itemsArr.push($(this).val());}
+                itemsArr.push($(this).val());}
             );
             tvtArr.push(itemsArr);
         });
-        var vl = JSON.stringify(tvtArr);
-        $('#'+fid).val(vl);
+
+        if (methods.checkArray(tvtArr)) {
+            var vl = JSON.stringify(tvtArr);
+            $('#'+fid).val(vl);
+        } else {
+            $('#'+fid).val('');
+        }
+
         MODx.fireResourceFormChange();
     }
 };
@@ -88,7 +110,7 @@ $('body, html').on('click', '.add_item', function(){
     $.myPlug('addItem', $(this).parent().find('input[type="text"]').length,$(this).parent(), $(this).closest('.tvtEditor').prev().attr('id'));
     $.myPlug('setEditor', $(this).closest('.tvtEditor').prev().attr('id'));
 });
-//delete row
+// delete row
 $('body, html').on('click', '.del_item', function(){
     var iff = $(this).closest('.tvtEditor').prev().attr('id')
     $(this).parent().remove();
@@ -107,9 +129,7 @@ $('body, html').on('click', '.del', function(){
 });
 // add column
 $('body, html').on('click', '.add', function(){
-        console.log(this)
     var iff = $(this).closest('.tvtEditor').prev().attr('id');
-    console.log('#' + iff +' .tvtEditor')
     $('#' + iff).next().find('div.tvtrow').each(function(item){
         methods.build('').insertAfter($(this).find('input[type=text]').last());
     });

--- a/assets/components/tvtable/js/mgr/tvtable.js
+++ b/assets/components/tvtable/js/mgr/tvtable.js
@@ -9,18 +9,20 @@ var TVTable = {
     }
     ,_checkArray: function(array) {
         if (!Ext.isArray(array)) return false;
-        var values = 0;
-        array.forEach(function(item, i, array) {
-            if (Ext.isArray(array)) {
-                item.forEach(function(item, i, array) {
-                    if (item !== '') {
-                        values++;
+        var result = false;
+
+        for (var x = 0; x < array.length; x++) {
+            var value = array[x];
+            if (Ext.isArray(value)) {
+                for (var y = 0; y < value.length; y++) {
+                    if (value[y] !== '') {
+                        return true;
                     }
-                });
+                }
             }
-        });
+        }
         
-        return values > 0 ? true : false;
+        return false;
     }
     ,_insertAfter: function (elem, refElem) {
         var parent = refElem.parentNode;
@@ -61,11 +63,7 @@ var TVTable = {
     }
     ,addHeader: function(values, field){
         var rowDiv = TVTable._createElement('div', {class: 'tvtrow header'});
-
-        var box = field.nextSibling;
-        while(box && box.nodeType != 1) {
-            box = box.nextSibling
-        }
+        var box = TVTable.getNextSibling(field);
         box.appendChild(rowDiv);
 
         if (!values) values = ['',''];
@@ -169,10 +167,7 @@ var TVTable = {
 
 document.onkeyup = function (e) {
     if (e.target.type == 'text') {
-        var prev = e.target.closest('.tvtEditor').previousSibling;
-        while (prev && prev.nodeType != 1) {
-            prev = prev.previousSibling;
-        }
+        var prev = TVTable.getPrevSibling(e.target.closest('.tvtEditor'));
         TVTable.setEditor(prev.id);
     }
 }
@@ -182,33 +177,22 @@ document.onclick = function (e) {
     if (e.target.classList.contains('add_item')) {
         var parent = e.target.parentNode;
         var length = parent.querySelectorAll('input[type="text"]').length;
-        var input = e.target.closest('.tvtEditor').previousSibling;
-    
-        while (input && input.nodeType != 1) {
-            input = input.previousSibling;
-        }
+        var input = TVTable.getPrevSibling(e.target.closest('.tvtEditor'));
     
         TVTable.addItem(length, parent, input.id);
         TVTable.setEditor(input.id);
     }
     // Remove row
     if (e.target.classList.contains('del_item')) {
-        var prev = e.target.closest('.tvtEditor').previousSibling;
         var parent = e.target.parentNode;
-        while (prev && prev.nodeType != 1) {
-            prev = prev.previousSibling;
-        }
+        var prev = TVTable.getPrevSibling(e.target.closest('.tvtEditor'));
 
         parent.remove();
         TVTable.setEditor(prev.id);
     }
     // delete column
     if (e.target.classList.contains('del')) {
-        var prev = e.target.closest('.tvtEditor').previousSibling;
-        while (prev && prev.nodeType != 1) {
-            prev = prev.previousSibling;
-        }
-
+        var prev = TVTable.getPrevSibling(e.target.closest('.tvtEditor'));
         var parent = e.target.parentNode;
         var length = parent.querySelectorAll('input[type="text"]').length;
         var next = TVTable.getNextSibling(prev);

--- a/core/components/tvtable/elements/plugins/plugin.tvtable.php
+++ b/core/components/tvtable/elements/plugins/plugin.tvtable.php
@@ -11,7 +11,6 @@ switch ($modx->event->name) {
 		break;
 	case 'OnDocFormPrerender':
         $modx->regClientCSS('/assets/components/tvtable/css/mgr/tvtable.css');
-        $modx->regClientStartupScript('//code.jquery.com/jquery-1.11.2.min.js');
 		$modx->regClientStartupScript('/assets/components/tvtable/js/mgr/tvtable.js');
 		break;
 	 case 'OnManagerPageBeforeRender':

--- a/core/components/tvtable/elements/plugins/plugin.tvtable.php
+++ b/core/components/tvtable/elements/plugins/plugin.tvtable.php
@@ -3,17 +3,17 @@
 $corePath = $modx->getOption('tvtable.core_path', null, $modx->getOption('core_path') . 'components/tvtable/');
 
 switch ($modx->event->name) {
-	case 'OnTVInputRenderList':
-		$modx->event->output($corePath . 'elements/tv/input/');
-		break;
-	case 'OnTVInputPropertiesList':
-		$modx->event->output($corePath . 'elements/tv/inputoptions/');
-		break;
-	case 'OnDocFormPrerender':
+    case 'OnTVInputRenderList':
+        $modx->event->output($corePath . 'elements/tv/input/');
+        break;
+    case 'OnTVInputPropertiesList':
+        $modx->event->output($corePath . 'elements/tv/inputoptions/');
+        break;
+    case 'OnDocFormPrerender':
         $modx->regClientCSS('/assets/components/tvtable/css/mgr/tvtable.css');
-		$modx->regClientStartupScript('/assets/components/tvtable/js/mgr/tvtable.js');
-		break;
-	 case 'OnManagerPageBeforeRender':
+        $modx->regClientStartupScript('/assets/components/tvtable/js/mgr/tvtable.js');
+        break;
+    case 'OnManagerPageBeforeRender':
         $modx->controller->addLexiconTopic('tvtable:default');
-         break;
+        break;
 }

--- a/core/components/tvtable/elements/snippets/snippet.tvtable.php
+++ b/core/components/tvtable/elements/snippets/snippet.tvtable.php
@@ -1,12 +1,11 @@
 <?php
     /** @var modX $modx */
     /** @var array $scriptProperties */
-    $tv = (int)$tv ;
+    $tv = (int) $tv;
     
-    if ($tv == 0  && $input == ''){
-        return ;
-    }
-    if($input == ''){
+    if ($tv == 0  && $input == '') return;
+
+    if ($input == '') {
         $resource = isset($id) ? $id : $modx->resource->id;
         $tvObject = $modx->getObject('modTemplateVarResource', array('tmplvarid' => $tv, 'contentid' => $resource ));
         if (!$tvObject){
@@ -14,13 +13,11 @@
         }
         
         $tvv = $tvObject->get('value');
-    }
-    else{
+    } else {
         $tvv = $input;
     }
-    if (!$tvv || $tvv=='[["",""],["",""]]') return;
     
-    $tvtArr=json_decode($tvv);
+    $tvtArr = $modx->fromJSON($tvv);
     
     if ($getX != '' and $getY != '') {
         if(isset($tvtArr[$getX][$getY])){

--- a/core/components/tvtable/elements/tv/tv.table.input.tpl
+++ b/core/components/tvtable/elements/tv/tv.table.input.tpl
@@ -1,11 +1,9 @@
-<input id="tv{$tv->id}" name="tv{$tv->id}" class="textfield" value="{$tv->get('value')|escape}" type = "text"/> 
+<input id="tv{$tv->id}" name="tv{$tv->id}" class="textfield" value="{$tv->get('value')|escape}" type="text"/> 
 <div class="tvtEditor"></div>
 <script type="text/javascript">  
     window.ie9=window.XDomainRequest && window.performance; window.ie=window.ie && !window.ie9; /* IE9 patch */
-     console.log('window')
     
-    $(document).ready(function () {
-    console.log('ready')
+    Ext.onReady(function() {
         var tvIds = "{$tv->id}";
         $.myPlug('init', "tv{$tv->id}");
     });

--- a/core/components/tvtable/elements/tv/tv.table.input.tpl
+++ b/core/components/tvtable/elements/tv/tv.table.input.tpl
@@ -5,6 +5,6 @@
     
     Ext.onReady(function() {
         var tvIds = "{$tv->id}";
-        $.myPlug('init', "tv{$tv->id}");
+        TVTable.init('tv' + {$tv->id});
     });
 </script>


### PR DESCRIPTION
### Зачем это нужно


**UPD:**
Переписан весь js на нативный, теперь всё ванильнее некуда!

____________________________________________________________________________________________

Если сохранить ресурс с пустыми ячейками, то в базу попадет пустой JSON массив
`[["",""], ["",""]]`

Впервые столкнулся с этой проблемой при использовании **fenom**, слепо поставил проверку в шаблоне и только потом обнаружил, что у ряда ресурсов в БД хранится такое `[["",""], ["",""]]` значение.

### Что я наделал

1. Добавил проверку, теперь если все ячейки пустые, то и из БД удалится значение.
2. Убрал выводы в консоль
3. ~~Поменял **parseJSON** от jQuery на **Ext.util.JSON.decode**~~
4. ~~Поменял ready от jQuery на Ext.onReady~~

~~Как будет время, и jQuery выпилить нужно будет~~

Выпилил jQuery